### PR TITLE
feat: Add 'Try Demo' button to login page

### DIFF
--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -18,6 +18,11 @@ export default function Login() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
 
+  const handleDemoLoginClick = () => {
+    setEmail('demo@sellor.ai');
+    setPassword('password123');
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsLoading(true);
@@ -146,20 +151,24 @@ export default function Login() {
               </button>
             </div>
           </form>
-          
-          {/* Demo credentials */}
-          <div className="mt-6">
+
+          <div className="mt-6"> {/* Container for the demo button, keeps spacing consistent */}
             <div className="relative">
               <div className="absolute inset-0 flex items-center">
                 <div className="w-full border-t border-gray-300" />
               </div>
               <div className="relative flex justify-center text-sm">
-                <span className="px-2 bg-white text-gray-500">Demo credentials</span>
+                <span className="px-2 bg-white text-gray-500">Or</span>
               </div>
             </div>
-            <div className="mt-4 text-center text-sm text-gray-600">
-              <p>Email: demo@sellor.ai</p>
-              <p>Password: password123</p>
+            <div className="mt-4">
+              <button
+                type="button"
+                onClick={handleDemoLoginClick}
+                className="w-full flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+              >
+                Try Demo Account
+              </button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Replaces the plain text display of demo credentials with a button that, when clicked, populates the email and password fields with the demo account details (demo@sellor.ai, password123).

The old static text display of demo credentials has been removed for a cleaner UI.

Note: This feature requires the corresponding demo user to be manually set up in the Supabase backend (Auth, users table, stores table) for the login to be successful.